### PR TITLE
add -fPIC to the static lib build

### DIFF
--- a/ebur128/CMakeLists.txt
+++ b/ebur128/CMakeLists.txt
@@ -40,6 +40,8 @@ set(EBUR128_VERSION 1.0.0)
 add_library(ebur128_static STATIC ebur128.c)
 set_target_properties(ebur128_static PROPERTIES
     OUTPUT_NAME ebur128)
+set_target_properties(ebur128_static PROPERTIES
+    COMPILE_FLAGS "-fPIC")
 add_library(ebur128 SHARED ebur128.c)
 set_target_properties(ebur128 PROPERTIES
     SOVERSION ${EBUR128_VERSION_MAJOR}


### PR DESCRIPTION
Before this change, if you try to create a shared object which depends on libebur128.a, you would get something like this:

/usr/bin/ld: /home/andy/dev/libgroove/deps/ebur128/build/libebur128.a(ebur128.c.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/home/andy/dev/libgroove/deps/ebur128/build/libebur128.a: could not read symbols: Bad value

After this change it works as expected.
