### PR TITLE
Add CMake option to disable static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,8 @@ include(GNUInstallDirs)
 add_subdirectory(ebur128)
 add_subdirectory(test)
 
-
 to_yes_no(SUMMARY_HAS_QUEUE SUMMARY_SPEEXDSP_FOUND)
 to_yes_no(DISABLE_SPEEXDSP)
-
-if(ENABLE_STATIC_LIBS)
-  message(STATUS "build static library and shared library!")
-else()
-  message(STATUS "not building static library, set ENABLE_STATIC_LIBS to ON to enable")
-endif()
 
 if(ENABLE_INTERNAL_QUEUE_H)
   set(USE_QUEUE "using own copy of queue.h")
@@ -31,6 +24,12 @@ endif()
 message(STATUS "Status          found / disabled --")
 message(STATUS "queue.h:        ${SUMMARY_HAS_QUEUE}"        "     ${USE_QUEUE}")
 message(STATUS "speexdsp:       ${SUMMARY_SPEEXDSP_FOUND}"   "     ${DISABLE_SPEEXDSP}")
+
+if(BUILD_STATIC_LIBS)
+  message(STATUS "build static library and shared library!")
+else()
+  message(STATUS "not building static library, set BUILD_STATIC_LIBS to ON to enable")
+endif()
 
 if(NOT SUMMARY_HAS_QUEUE AND NOT ENABLE_INTERNAL_QUEUE_H)
   message(FATAL_ERROR "queue.h not found, please set ENABLE_INTERNAL_QUEUE_H to ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,12 @@ add_subdirectory(test)
 to_yes_no(SUMMARY_HAS_QUEUE SUMMARY_SPEEXDSP_FOUND)
 to_yes_no(DISABLE_SPEEXDSP)
 
+if(ENABLE_STATIC_LIBS)
+  message(STATUS "build static library and shared library!")
+else()
+  message(STATUS "not building static library, set ENABLE_STATIC_LIBS to ON to enable")
+endif()
+
 if(ENABLE_INTERNAL_QUEUE_H)
   set(USE_QUEUE "using own copy of queue.h")
 else()
@@ -22,7 +28,7 @@ else()
 endif()
 
 ##### Print status
-message(STATUS "status          found / disabled --")
+message(STATUS "Status          found / disabled --")
 message(STATUS "queue.h:        ${SUMMARY_HAS_QUEUE}"        "     ${USE_QUEUE}")
 message(STATUS "speexdsp:       ${SUMMARY_SPEEXDSP_FOUND}"   "     ${DISABLE_SPEEXDSP}")
 

--- a/ebur128/CMakeLists.txt
+++ b/ebur128/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.9)
 
-set(ENABLE_STATIC_LIBS      ON  CACHE BOOL "Build static library")
+set(BUILD_STATIC_LIBS       ON  CACHE BOOL "Build static library")
 set(WITH_STATIC_PIC         OFF CACHE BOOL "Compile static library with -fPIC flag")
 set(ENABLE_INTERNAL_QUEUE_H OFF CACHE BOOL "Use own queue.h")
 set(DISABLE_SPEEXDSP        OFF CACHE BOOL "Don't build with speexdsp")
@@ -36,7 +36,7 @@ endif()
 set(EBUR128_VERSION_MAJOR 1)
 set(EBUR128_VERSION 1.0.1)
 
-if(ENABLE_STATIC_LIBS)
+if(BUILD_STATIC_LIBS)
 add_library(ebur128_static STATIC ebur128.c)
 set_property(TARGET ebur128_static PROPERTY OUTPUT_NAME ebur128)
 endif()
@@ -51,24 +51,24 @@ set_target_properties(ebur128 PROPERTIES
     VERSION ${EBUR128_VERSION})
 
 if(UNIX)
-  target_link_libraries(ebur128 -lm)
+  target_link_libraries(ebur128 m)
 endif(UNIX)
 
 if(SPEEXDSP_FOUND AND NOT DISABLE_SPEEXDSP)
-    if(ENABLE_STATIC_LIBS)
+    if(BUILD_STATIC_LIBS)
       set_property(TARGET ebur128_static APPEND_STRING PROPERTY
           COMPILE_FLAGS " ${SPEEXDSP_CFLAGS}")
     endif()
-set_property(TARGET ebur128 APPEND_STRING PROPERTY
-    COMPILE_FLAGS " ${SPEEXDSP_CFLAGS}")
-target_link_libraries(ebur128 ${SPEEXDSP_LIBRARIES})
+  set_property(TARGET ebur128 APPEND_STRING PROPERTY
+      COMPILE_FLAGS " ${SPEEXDSP_CFLAGS}")
+  target_link_libraries(ebur128 ${SPEEXDSP_LIBRARIES})
 endif()
 
 set(SUMMARY_SPEEXDSP_FOUND ${SPEEXDSP_FOUND} CACHE INTERNAL "")
 set(EBUR128_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "")
 
 install(FILES ebur128.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-if(ENABLE_STATIC_LIBS)
+if(BUILD_STATIC_LIBS)
 install(TARGETS ebur128 ebur128_static DESTINATION ${CMAKE_INSTALL_LIBDIR})
 else()
 install(TARGETS ebur128 DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/ebur128/CMakeLists.txt
+++ b/ebur128/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 2.8.9)
 
+set(ENABLE_STATIC_LIBS      ON  CACHE BOOL "Build static library")
 set(WITH_STATIC_PIC         OFF CACHE BOOL "Compile static library with -fPIC flag")
 set(ENABLE_INTERNAL_QUEUE_H OFF CACHE BOOL "Use own queue.h")
 set(DISABLE_SPEEXDSP        OFF CACHE BOOL "Don't build with speexdsp")
-
 
 #### queue.h
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/queuetest.c
@@ -36,8 +36,11 @@ endif()
 set(EBUR128_VERSION_MAJOR 1)
 set(EBUR128_VERSION 1.0.1)
 
+if(ENABLE_STATIC_LIBS)
 add_library(ebur128_static STATIC ebur128.c)
 set_property(TARGET ebur128_static PROPERTY OUTPUT_NAME ebur128)
+endif()
+
 if(WITH_STATIC_PIC)
     set_property(TARGET ebur128_static PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
@@ -52,16 +55,21 @@ if(UNIX)
 endif(UNIX)
 
 if(SPEEXDSP_FOUND AND NOT DISABLE_SPEEXDSP)
-    set_property(TARGET ebur128_static APPEND_STRING PROPERTY
-        COMPILE_FLAGS " ${SPEEXDSP_CFLAGS}")
-    set_property(TARGET ebur128 APPEND_STRING PROPERTY
-        COMPILE_FLAGS " ${SPEEXDSP_CFLAGS}")
-    target_link_libraries(ebur128 ${SPEEXDSP_LIBRARIES})
+    if(ENABLE_STATIC_LIBS)
+      set_property(TARGET ebur128_static APPEND_STRING PROPERTY
+          COMPILE_FLAGS " ${SPEEXDSP_CFLAGS}")
+    endif()
+set_property(TARGET ebur128 APPEND_STRING PROPERTY
+    COMPILE_FLAGS " ${SPEEXDSP_CFLAGS}")
+target_link_libraries(ebur128 ${SPEEXDSP_LIBRARIES})
 endif()
-
 
 set(SUMMARY_SPEEXDSP_FOUND ${SPEEXDSP_FOUND} CACHE INTERNAL "")
 set(EBUR128_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "")
 
 install(FILES ebur128.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(ENABLE_STATIC_LIBS)
 install(TARGETS ebur128 ebur128_static DESTINATION ${CMAKE_INSTALL_LIBDIR})
+else()
+install(TARGETS ebur128 DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()


### PR DESCRIPTION
This patch let packagers determine if they need static library or not, it will notably save the space if static library is not needed.