### PR TITLE
Release v1.0.3

### DIFF
--- a/ebur128/CMakeLists.txt
+++ b/ebur128/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 
 set(EBUR128_VERSION_MAJOR 1)
-set(EBUR128_VERSION 1.0.1)
+set(EBUR128_VERSION 1.0.3)
 
 #### static
 if(BUILD_STATIC_LIBS)


### PR DESCRIPTION
I'm maintaining the Gentoo package for this library and would like to use the new static libs build option (#34), but the patch does not apply cleanly over v1.0.2.

If you made a new release, that would make my life easier.

Thanks. :)