### PR TITLE
Implementation of new channels positions from ITU R BS. 1770-4

### DIFF
--- a/ebur128/ebur128.c
+++ b/ebur128/ebur128.c
@@ -456,7 +456,7 @@ static void ebur128_filter_##type(ebur128_state* st, const type* src,          \
   for (c = 0; c < st->channels; ++c) {                                         \
     int ci = st->d->channel_map[c] - 1;                                        \
     if (ci < 0) continue;                                                      \
-    else if (ci > 4) ci = 0; /* dual mono */                                   \
+    else if (ci == EBUR128_DUAL_MONO - 1) ci = 0; /*dual mono */               \
     for (i = 0; i < frames; ++i) {                                             \
       st->d->v[ci][0] = (double) (src[i * st->channels + c] / scaling_factor)  \
                    - st->d->a[1] * st->d->v[ci][1]                             \
@@ -532,8 +532,12 @@ static int ebur128_calc_gating_block(ebur128_state* st, size_t frames_per_block,
                        st->d->audio_data[i * st->channels + c];
       }
     }
-    if (st->d->channel_map[c] == EBUR128_LEFT_SURROUND ||
-        st->d->channel_map[c] == EBUR128_RIGHT_SURROUND) {
+    if (st->d->channel_map[c] == EBUR128_Mp110 ||
+        st->d->channel_map[c] == EBUR128_Mm110 ||
+        st->d->channel_map[c] == EBUR128_Mp060 ||
+        st->d->channel_map[c] == EBUR128_Mm060 ||
+        st->d->channel_map[c] == EBUR128_Mp090 ||
+        st->d->channel_map[c] == EBUR128_Mm090) {
       channel_sum *= 1.41;
     } else if (st->d->channel_map[c] == EBUR128_DUAL_MONO) {
       channel_sum *= 2.0;

--- a/ebur128/ebur128.h
+++ b/ebur128/ebur128.h
@@ -20,15 +20,46 @@ extern "C" {
 
 /** \enum channel
  *  Use these values when setting the channel map with ebur128_set_channel().
+ *  See definitions in ITU R-REC-BS 1770-4
  */
 enum channel {
   EBUR128_UNUSED = 0,     /**< unused channel (for example LFE channel) */
-  EBUR128_LEFT,           /**< left channel */
-  EBUR128_RIGHT,          /**< right channel */
-  EBUR128_CENTER,         /**< center channel */
-  EBUR128_LEFT_SURROUND,  /**< left surround channel */
-  EBUR128_RIGHT_SURROUND, /**< right surround channel */
-  EBUR128_DUAL_MONO       /**< a channel that is counted twice */
+  EBUR128_LEFT,
+  EBUR128_Mp030 = 1,      /**< itu M+030 */
+  EBUR128_RIGHT,
+  EBUR128_Mm030 = 2,      /**< itu M-030 */
+  EBUR128_CENTER,
+  EBUR128_Mp000 = 3,      /**< itu M+000 */
+  EBUR128_LEFT_SURROUND,
+  EBUR128_Mp110 = 4,      /**< itu M+110 */
+  EBUR128_RIGHT_SURROUND,
+  EBUR128_Mm110 = 5,      /**< itu M-110 */
+  EBUR128_DUAL_MONO,      /**< a channel that is counted twice */
+  EBUR128_MpSC,           /**< itu M+SC */
+  EBUR128_MmSC,           /**< itu M-SC */
+  EBUR128_Mp060,          /**< itu M+060 */
+  EBUR128_Mm060,          /**< itu M-060 */
+  EBUR128_Mp090,          /**< itu M+090 */
+  EBUR128_Mm090,          /**< itu M-090 */
+  EBUR128_Mp135,          /**< itu M+135 */
+  EBUR128_Mm135,          /**< itu M-135 */
+  EBUR128_Mp180,          /**< itu M+180 */
+  EBUR128_Up000,          /**< itu U+000 */
+  EBUR128_Up030,          /**< itu U+030 */
+  EBUR128_Um030,          /**< itu U-030 */
+  EBUR128_Up045,          /**< itu U+045 */
+  EBUR128_Um045,          /**< itu U-030 */
+  EBUR128_Up090,          /**< itu U+090 */
+  EBUR128_Um090,          /**< itu U-090 */
+  EBUR128_Up110,          /**< itu U+110 */
+  EBUR128_Um110,          /**< itu U-110 */
+  EBUR128_Up135,          /**< itu U+135 */
+  EBUR128_Um135,          /**< itu U-135 */
+  EBUR128_Up180,          /**< itu U+180 */
+  EBUR128_Tp000,          /**< itu T+000 */
+  EBUR128_Bp000,          /**< itu B+000 */
+  EBUR128_Bp045,          /**< itu B+045 */
+  EBUR128_Bm045           /**< itu B-045 */
 };
 
 /** \enum error


### PR DESCRIPTION
Hello,
here's a proposal to implement new channels positions as defined in ITU R BS. 1770-4 (http://www.itu.int/rec/R-REC-BS.1770-4-201510-I/en).

Trying to stay compatible with previous API and therefore not breaking loudness-scanner current code. Tested with loudness-scanner against the ebu test set and the itu test set without issues.

I'm not sure of the way to deal with the DUAL_MONO case, though. 