### PR TITLE
add ebur128_relative_threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ See also [loudness-scanner tool](https://github.com/jiixyj/loudness-scanner).
 
 News
 ----
+v1.1 Released:
+
+  * Add `ebur128_relative_threshold()`
 
 v1.0.3 Released:
 

--- a/ebur128/ebur128.c
+++ b/ebur128/ebur128.c
@@ -800,6 +800,11 @@ int ebur128_relative_threshold(ebur128_state* st, double* out) {
 
   ebur128_calc_relative_threshold(st, &above_thresh_counter, &relative_threshold);
 
+  if (!above_thresh_counter) {
+      *out = -70.0;
+      return EBUR128_SUCCESS;
+  }
+
   *out = ebur128_energy_to_loudness(relative_threshold);
   return EBUR128_SUCCESS;
 }

--- a/ebur128/ebur128.c
+++ b/ebur128/ebur128.c
@@ -706,12 +706,39 @@ EBUR128_ADD_FRAMES(int)
 EBUR128_ADD_FRAMES(float)
 EBUR128_ADD_FRAMES(double)
 
+static int ebur128_calc_relative_threshold(ebur128_state* st,
+                                           size_t* above_thresh_counter,
+                                           double* relative_threshold) {
+  struct ebur128_dq_entry* it;
+  size_t i;
+  *relative_threshold = 0.0;
+  *above_thresh_counter = 0;
+
+  if (st->d->use_histogram) {
+    for (i = 0; i < 1000; ++i) {
+      *relative_threshold += st->d->block_energy_histogram[i] *
+                            histogram_energies[i];
+      *above_thresh_counter += st->d->block_energy_histogram[i];
+    }
+  } else {
+    SLIST_FOREACH(it, &st->d->block_list, entries) {
+      ++*above_thresh_counter;
+      *relative_threshold += it->z;
+    }
+  }
+
+  *relative_threshold /= (double) *above_thresh_counter;
+  *relative_threshold *= relative_gate_factor;
+
+  return EBUR128_SUCCESS;
+}
+
 static int ebur128_gated_loudness(ebur128_state** sts, size_t size,
                                   double* out) {
   struct ebur128_dq_entry* it;
-  double relative_threshold = 0.0;
   double gated_loudness = 0.0;
-  size_t above_thresh_counter = 0;
+  double relative_threshold;
+  size_t above_thresh_counter;
   size_t i, j, start_index;
 
   for (i = 0; i < size; i++) {
@@ -722,25 +749,13 @@ static int ebur128_gated_loudness(ebur128_state** sts, size_t size,
 
   for (i = 0; i < size; i++) {
     if (!sts[i]) continue;
-    if (sts[i]->d->use_histogram) {
-      for (j = 0; j < 1000; ++j) {
-        relative_threshold += sts[i]->d->block_energy_histogram[j] *
-                              histogram_energies[j];
-        above_thresh_counter += sts[i]->d->block_energy_histogram[j];
-      }
-    } else {
-      SLIST_FOREACH(it, &sts[i]->d->block_list, entries) {
-        ++above_thresh_counter;
-        relative_threshold += it->z;
-      }
-    }
+    ebur128_calc_relative_threshold(sts[i], &above_thresh_counter, &relative_threshold);
   }
   if (!above_thresh_counter) {
     *out = -HUGE_VAL;
     return EBUR128_SUCCESS;
   }
-  relative_threshold /= (double) above_thresh_counter;
-  relative_threshold *= relative_gate_factor;
+
   above_thresh_counter = 0;
   if (relative_threshold < histogram_energy_boundaries[0]) {
     start_index = 0;
@@ -777,29 +792,13 @@ static int ebur128_gated_loudness(ebur128_state** sts, size_t size,
 }
 
 int ebur128_relative_threshold(ebur128_state* st, double* out) {
-  struct ebur128_dq_entry* it;
-  double relative_threshold = 0.0;
-  size_t above_thresh_counter = 0;
-  size_t i;
+  double relative_threshold;
+  size_t above_thresh_counter;
 
   if (st && (st->mode & EBUR128_MODE_I) != EBUR128_MODE_I)
     return EBUR128_ERROR_INVALID_MODE;
 
-  if (st->d->use_histogram) {
-    for (i = 0; i < 1000; ++i) {
-      relative_threshold += st->d->block_energy_histogram[i] *
-                            histogram_energies[i];
-      above_thresh_counter += st->d->block_energy_histogram[i];
-    }
-  } else {
-    SLIST_FOREACH(it, &st->d->block_list, entries) {
-      ++above_thresh_counter;
-      relative_threshold += it->z;
-    }
-  }
-
-  relative_threshold /= (double) above_thresh_counter;
-  relative_threshold *= relative_gate_factor;
+  ebur128_calc_relative_threshold(st, &above_thresh_counter, &relative_threshold);
 
   *out = ebur128_energy_to_loudness(relative_threshold);
   return EBUR128_SUCCESS;

--- a/ebur128/ebur128.h
+++ b/ebur128/ebur128.h
@@ -13,8 +13,8 @@ extern "C" {
 #endif
 
 #define EBUR128_VERSION_MAJOR 1
-#define EBUR128_VERSION_MINOR 0
-#define EBUR128_VERSION_PATCH 4
+#define EBUR128_VERSION_MINOR 1
+#define EBUR128_VERSION_PATCH 0
 
 #include <stddef.h>       /* for size_t */
 

--- a/ebur128/ebur128.h
+++ b/ebur128/ebur128.h
@@ -14,7 +14,7 @@ extern "C" {
 
 #define EBUR128_VERSION_MAJOR 1
 #define EBUR128_VERSION_MINOR 0
-#define EBUR128_VERSION_PATCH 3
+#define EBUR128_VERSION_PATCH 4
 
 #include <stddef.h>       /* for size_t */
 
@@ -82,7 +82,7 @@ enum mode {
   EBUR128_MODE_M           = (1 << 0),
   /** can call ebur128_loudness_shortterm */
   EBUR128_MODE_S           = (1 << 1) | EBUR128_MODE_M,
-  /** can call ebur128_loudness_global_* */
+  /** can call ebur128_loudness_global_* and ebur128_relative_threshold */
   EBUR128_MODE_I           = (1 << 2) | EBUR128_MODE_M,
   /** can call ebur128_loudness_range */
   EBUR128_MODE_LRA         = (1 << 3) | EBUR128_MODE_S,
@@ -311,6 +311,17 @@ int ebur128_sample_peak(ebur128_state* st,
 int ebur128_true_peak(ebur128_state* st,
                       unsigned int channel_number,
                       double* out);
+
+/** \brief Get relative threshold in LUFS.
+ *
+ *  @param st library state
+ *  @param out relative threshold in LUFS.
+ *  @return
+ *    - EBUR128_SUCCESS on success.
+ *    - EBUR128_ERROR_INVALID_MODE if mode "EBUR128_MODE_I" has not
+ *      been set.
+ */
+int ebur128_relative_threshold(ebur128_state* st, double* out);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This exposes the relative gating threshold. This is a useful value for R128 based dynamic processing and metering.