### PR TITLE
Export functions when compiling on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
   message(STATUS "not building static library, set BUILD_STATIC_LIBS to ON to enable")
 endif()
 
-if(NOT SUMMARY_HAS_QUEUE AND NOT ENABLE_INTERNAL_QUEUE_H)
+if(NOT ${SUMMARY_HAS_QUEUE} AND NOT ${ENABLE_INTERNAL_QUEUE_H})
   message(FATAL_ERROR "queue.h not found, please set ENABLE_INTERNAL_QUEUE_H to ON")
 endif()
 

--- a/ebur128/CMakeLists.txt
+++ b/ebur128/CMakeLists.txt
@@ -18,6 +18,8 @@ endif()
 
 if(MSVC)
   add_definitions(-D_USE_MATH_DEFINES)
+  add_definitions(/arch:SSE2)
+  add_definitions(-D __SSE2_MATH__)
 endif()
 
 
@@ -35,7 +37,13 @@ if(WITH_STATIC_PIC)
 endif()
 
 #### shared
-add_library(ebur128 SHARED ebur128.c)
+# set source file for library, which includes def file if using MSVC
+set(EBUR128_SHARED_SOURCE ebur128.c)
+if(MSVC)
+  set(EBUR128_SHARED_SOURCE ${EBUR128_SHARED_SOURCE} ebur128.def)
+endif()
+
+add_library(ebur128 SHARED ${EBUR128_SHARED_SOURCE})
 set_target_properties(ebur128 PROPERTIES
     SOVERSION ${EBUR128_VERSION_MAJOR}
     VERSION ${EBUR128_VERSION})

--- a/ebur128/ebur128.def
+++ b/ebur128/ebur128.def
@@ -1,0 +1,19 @@
+LIBRARY EBUR128
+
+EXPORTS
+	ebur128_get_version
+	ebur128_init
+	ebur128_destroy
+	ebur128_set_channel
+	ebur128_change_parameters
+	ebur128_add_frames_short
+	ebur128_add_frames_int
+	ebur128_add_frames_float
+	ebur128_add_frames_double
+	ebur128_loudness_global
+	ebur128_loudness_global_multiple
+	ebur128_loudness_momentary
+	ebur128_loudness_shortterm
+	ebur128_loudness_range
+	ebur128_loudness_range_multiple
+	ebur128_sample_peak


### PR DESCRIPTION
Add DEF file for ensuring functions are exported when building a
shared library on Windows.

Also adds flags to ensure SSE2 is used with MSVC.

This should close issue #40 (the definitions added should ensure SSE2 is used on MSVC, so the warning should no longer occur). 