### PR TITLE
Move variable declarations to beginning of scope to avoid error C2143

### DIFF
--- a/ebur128/ebur128.c
+++ b/ebur128/ebur128.c
@@ -162,18 +162,21 @@ static void interp_process(interpolator* interp, size_t frames, float* in, float
   unsigned int f = 0;
   unsigned int t = 0;
   unsigned int out_stride = interp->channels * interp->factor;
+  float* outp = 0;
+  double acc = 0;
+  double c = 0;
   for (frame = 0; frame < frames; frame++) {
     for (chan = 0; chan < interp->channels; chan++) {
       // Add sample to delay buffer
       interp->z[chan][interp->zi] = *in++;
       // Apply coefficients
-      float* outp = out + chan;
+      outp = out + chan;
       for (f = 0; f < interp->factor; f++) {
-        double acc = 0.0;
+        acc = 0.0;
         for (t = 0; t < interp->filter[f].count; t++) {
           int i = (int)interp->zi - (int)interp->filter[f].index[t];
           if (i < 0) i += interp->delay;
-          double c = interp->filter[f].coeff[t];
+          c = interp->filter[f].coeff[t];
           acc += interp->z[chan][i] * c;
         }
         *outp = (float)acc;


### PR DESCRIPTION
Microsoft Visual C++, at least version 2008, does not allow any variable declarations other than at the top of the scope.

The code in interp_process() has three such declarations (outp, acc, c), which will make the compilation fail with error C2143.

This PR fixes the issue by moving all declarations at the top of the function.