### PR TITLE
MSVC SSE2 Cleanup

### DIFF
--- a/ebur128/CMakeLists.txt
+++ b/ebur128/CMakeLists.txt
@@ -17,8 +17,9 @@ endif()
 
 if(MSVC)
   add_definitions(-D_USE_MATH_DEFINES)
-  add_definitions(/arch:SSE2)
-  add_definitions(-D __SSE2_MATH__)
+  if(CMAKE_SIZEOF_VOID_P LESS 8)
+    add_definitions(/arch:SSE2)
+  endif()
 endif()
 
 

--- a/ebur128/ebur128.c
+++ b/ebur128/ebur128.c
@@ -528,7 +528,7 @@ static void ebur128_check_true_peak(ebur128_state* st, size_t frames) {
   }
 }
 
-#ifdef __SSE2_MATH__
+#if defined(__SSE2_MATH__) || defined(_M_X64) || _M_IX86_FP >= 2
 #include <xmmintrin.h>
 #define TURN_ON_FTZ \
         unsigned int mxcsr = _mm_getcsr(); \


### PR DESCRIPTION
Don't add `/arch:SSE2` on x64, as it doesn't exist on that architecture, causing a warning (SSE2 is always supported and enabled) and don't define reserved identifiers (`__SSE2_MATH__` contains double underscores).