### PR TITLE
use size_t instead of unsigned long for needed_frames

### DIFF
--- a/ebur128/ebur128.c
+++ b/ebur128/ebur128.c
@@ -49,7 +49,7 @@ struct ebur128_state_internal {
   /** How many frames are needed for a gating block. Will correspond to 400ms
    *  of audio at initialization, and 100ms after the first block (75% overlap
    *  as specified in the 2011 revision of BS1770). */
-  unsigned long needed_frames;
+  size_t needed_frames;
   /** The channel map. Has as many elements as there are channels. */
   int* channel_map;
   /** How many samples fit in 100ms (rounded). */


### PR DESCRIPTION
`ebur128_add_frames_##type` uses `size_t` for frames, while `ebur128_state_internal` uses `unsigned long` for `needed_frames`. On Windows x64, `unsigned long` is a 32 bit unsigned integer, while `size_t` is a 64 bit unsigned integer, causing several warnings. The patch changes the definition of `ebur128_state_internal` instead of changing `ebur128_add_frames_##type`, as the latter is part of the public API.