### PR TITLE
CMake: Respect the BUILD_SHARED_LIBS option instead of BUILD_STATIC_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ message(STATUS "Status          found / disabled --")
 message(STATUS "queue.h:        ${SUMMARY_HAS_QUEUE}"        "     ${USE_QUEUE}")
 
 if(BUILD_SHARED_LIBS)
-  message(STATUS "Building shared library (set BUILD_SHARED_LIBS to NO to build static)")
+  message(STATUS "Building shared library (set BUILD_SHARED_LIBS to OFF to build static)")
 else()
   message(STATUS "Building static library")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 project(libebur128 C)
 
+option(BUILD_SHARED_LIBS
+    "Build shared libraries instead of static ones" ON)
+
 if(ENABLE_FUZZER)
   enable_language(CXX)
   set(SANITIZER_FLAGS "-fsanitize=address,undefined,unsigned-integer-overflow")
@@ -29,10 +32,10 @@ endif()
 message(STATUS "Status          found / disabled --")
 message(STATUS "queue.h:        ${SUMMARY_HAS_QUEUE}"        "     ${USE_QUEUE}")
 
-if(BUILD_STATIC_LIBS)
-  message(STATUS "build static library and shared library!")
+if(BUILD_SHARED_LIBS)
+  message(STATUS "Building shared library (set BUILD_SHARED_LIBS to NO to build static)")
 else()
-  message(STATUS "not building static library, set BUILD_STATIC_LIBS to ON to enable")
+  message(STATUS "Building static library")
 endif()
 
 if(ENABLE_TESTS)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ See also [loudness-scanner tool](https://github.com/jiixyj/loudness-scanner).
 News
 ----
 
+Next release:
+ * Remove `BUILD_STATIC_LIBS` build option. Instead the CMake-supported
+   `BUILD_SHARED_LIBS` option is now honored as expected.
+
 v1.2.4 released:
  * Fix broken `ebur128_loudness_global_multiple()` function. Since v1.1.0 it
    calculated the relative threshold just from the last state given to it,

--- a/ebur128/CMakeLists.txt
+++ b/ebur128/CMakeLists.txt
@@ -30,59 +30,55 @@ endif()
 set(EBUR128_VERSION_MAJOR 1)
 set(EBUR128_VERSION 1.2.4)
 
-#### static
-if(BUILD_STATIC_LIBS)
-  add_library(ebur128_static STATIC ebur128.c)
-  if(NOT MSVC)
-    set_property(TARGET ebur128_static PROPERTY OUTPUT_NAME ebur128)
+add_library(ebur128 ebur128.c)
+
+if(NOT BUILD_SHARED_LIBS)
+  # Static build specific things
+  if(WITH_STATIC_PIC)
+    set_property(TARGET ebur128 PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+    set_target_properties(ebur128 PROPERTIES
+      SOVERSION ${EBUR128_VERSION_MAJOR}
+      VERSION ${EBUR128_VERSION})
+  endif()
+
+else()
+  # Share build specific things
+  set_target_properties(ebur128 PROPERTIES
+    SOVERSION ${EBUR128_VERSION_MAJOR}
+    VERSION ${EBUR128_VERSION})
+
+  if(WIN32)
+    set_target_properties(ebur128 PROPERTIES
+      OUTPUT_NAME ebur128
+      RUNTIME_OUTPUT_NAME ebur128-${EBUR128_VERSION_MAJOR}
+      ARCHIVE_OUTPUT_NAME ebur128)
+  endif(WIN32)
+
+  if(MSVC)
+    target_sources(ebur128 PRIVATE ebur128.def)
   endif()
 endif()
 
-if(WITH_STATIC_PIC)
-  set_property(TARGET ebur128_static PROPERTY POSITION_INDEPENDENT_CODE ON)
+# Link with Math library if available
+find_library(MATH_LIBRARY m)
+if(MATH_LIBRARY)
+  target_link_libraries(ebur128 ${MATH_LIBRARY})
 endif()
 
-#### shared
-# set source file for library, which includes def file if using MSVC
-set(EBUR128_SHARED_SOURCE ebur128.c)
-if(MSVC)
-  set(EBUR128_SHARED_SOURCE ${EBUR128_SHARED_SOURCE} ebur128.def)
-endif()
-
-add_library(ebur128 SHARED ${EBUR128_SHARED_SOURCE})
-set_target_properties(ebur128 PROPERTIES
-    SOVERSION ${EBUR128_VERSION_MAJOR}
-    VERSION ${EBUR128_VERSION})
-if(WIN32)
-  set_target_properties(ebur128 
-    PROPERTIES OUTPUT_NAME ebur128 RUNTIME_OUTPUT_NAME ebur128-${EBUR128_VERSION_MAJOR}
-    ARCHIVE_OUTPUT_NAME ebur128)
-endif(WIN32)
 if(ENABLE_FUZZER)
   target_compile_options(ebur128 PUBLIC "${FUZZER_FLAGS}")
   target_compile_definitions(ebur128 PRIVATE malloc=my_malloc calloc=my_calloc)
   target_link_libraries(ebur128 "${SANITIZER_FLAGS}")
 endif()
 
-find_library(MATH_LIBRARY m)
-if(MATH_LIBRARY)
-  target_link_libraries(ebur128 ${MATH_LIBRARY})
-endif()
-
 set(EBUR128_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "")
 
 install(FILES ebur128.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-if(BUILD_STATIC_LIBS)
-  install(TARGETS ebur128 ebur128_static
-          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-else()
-  install(TARGETS ebur128
-          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()
+install(TARGETS ebur128
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 #### pkg-config
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libebur128.pc.cmake


### PR DESCRIPTION
Instead of the custom `BUILD_STATIC_LIBS` option, properly respect the
`BUILD_SHARED_LIBS` option as documented by CMake at
https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html

Fix #107 