### PR TITLE
fix Windows DLL link with MSVC + add GitHub Actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - name: Ubuntu 20.04
+            os: ubuntu-20.04
+            install_dir: ~/libebur128
+            cmake_extras: -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          - name: macOS 10.15
+            os: macos-10.15
+            install_dir: ~/libebur128
+            cmake_extras: -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          - name: Windows 2019
+            os: windows-2019
+            install_dir: C:\libebur128
+            cmake_extras: -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
+            cmake_config: --config RelWithDebInfo
+            ctest_config: --build-config RelWithDebInfo
+
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Check out Git repository
+      uses: actions/checkout@v2
+    - name: Configure
+      run: cmake -DCMAKE_INSTALL_PREFIX=${{ matrix.install_dir }} -DBUILD_SHARED_LIBS=ON
+           ${{ matrix.cmake_extras }} -S . -B build
+    - name: Build
+      run: cmake --build build ${{ matrix.cmake_config }}
+      env:
+        CMAKE_BUILD_PARALLEL_LEVEL: 2
+    # TODO: build and run tests and fuzzer
+    - name: Install
+      run: cmake --install build ${{ matrix.cmake_config }}
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.name }} libebur128 build
+        path: ${{ matrix.install_dir }}

--- a/ebur128/CMakeLists.txt
+++ b/ebur128/CMakeLists.txt
@@ -48,13 +48,6 @@ else()
     SOVERSION ${EBUR128_VERSION_MAJOR}
     VERSION ${EBUR128_VERSION})
 
-  if(WIN32)
-    set_target_properties(ebur128 PROPERTIES
-      OUTPUT_NAME ebur128
-      RUNTIME_OUTPUT_NAME ebur128-${EBUR128_VERSION_MAJOR}
-      ARCHIVE_OUTPUT_NAME ebur128)
-  endif(WIN32)
-
   if(MSVC)
     target_sources(ebur128 PRIVATE ebur128.def)
   endif()

--- a/ebur128/CMakeLists.txt
+++ b/ebur128/CMakeLists.txt
@@ -31,25 +31,18 @@ set(EBUR128_VERSION_MAJOR 1)
 set(EBUR128_VERSION 1.2.5)
 
 add_library(ebur128 ebur128.c)
+set_target_properties(ebur128 PROPERTIES
+  SOVERSION ${EBUR128_VERSION_MAJOR}
+  VERSION ${EBUR128_VERSION}
+)
 
-if(NOT BUILD_SHARED_LIBS)
-  # Static build specific things
-  if(WITH_STATIC_PIC)
-    set_property(TARGET ebur128 PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-    set_target_properties(ebur128 PROPERTIES
-      SOVERSION ${EBUR128_VERSION_MAJOR}
-      VERSION ${EBUR128_VERSION})
-  endif()
-
-else()
-  # Share build specific things
-  set_target_properties(ebur128 PROPERTIES
-    SOVERSION ${EBUR128_VERSION_MAJOR}
-    VERSION ${EBUR128_VERSION})
-
+if(BUILD_SHARED_LIBS)
   if(MSVC)
     target_sources(ebur128 PRIVATE ebur128.def)
+  endif()
+else()
+  if(WITH_STATIC_PIC)
+    set_property(TARGET ebur128 PROPERTY POSITION_INDEPENDENT_CODE ON)
   endif()
 endif()
 


### PR DESCRIPTION
The first commit adds a GitHub Actions workflow file that builds libebur128 on Ubuntu, macOS, and Windows. The Windows build shows this warning:
```
Run cmake --build build --config RelWithDebInfo
Microsoft (R) Build Engine version 16.8.3+39993bd9d for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  Building Custom Rule D:/a/libebur128/libebur128/ebur128/CMakeLists.txt
  ebur128.c
     Creating library D:/a/libebur128/libebur128/build/RelWithDebInfo/ebur128.lib and object D:/a/libebur128/libebur128/build/RelWithDebInfo/ebur128.exp
ebur128.exp : warning LNK4070: /OUT:EBUR128.dll directive in .EXP differs from output filename 'D:\a\libebur128\libebur128\build\RelWithDebInfo\ebur128-1.dll'; ignoring directive [D:\a\libebur128\libebur128\build\ebur128\ebur128.vcxproj]
  ebur128.vcxproj -> D:\a\libebur128\libebur128\build\RelWithDebInfo\ebur128-1.dll
  Building Custom Rule D:/a/libebur128/libebur128/CMakeLists.txt
```
This is fixed in the subsequent commit.