### PR TITLE
fix overflow when calculating number of frames in a window for dsd512…

### DIFF
--- a/ebur128/ebur128.c
+++ b/ebur128/ebur128.c
@@ -455,7 +455,7 @@ ebur128_init(unsigned int channels, unsigned long samplerate, int mode) {
   } else {
     goto free_prev_true_peak;
   }
-  st->d->audio_data_frames = st->samplerate * st->d->window / 1000;
+  st->d->audio_data_frames = (st->samplerate / 1000) * st->d->window;
   if (st->d->audio_data_frames % st->d->samples_in_100ms) {
     /* round up to multiple of samples_in_100ms */
     st->d->audio_data_frames =

--- a/ebur128/ebur128.c
+++ b/ebur128/ebur128.c
@@ -455,7 +455,7 @@ ebur128_init(unsigned int channels, unsigned long samplerate, int mode) {
   } else {
     goto free_prev_true_peak;
   }
-  st->d->audio_data_frames = (st->samplerate / 1000) * st->d->window;
+  st->d->audio_data_frames = ((unsigned long long)st->samplerate) * st->d->window / 1000;
   if (st->d->audio_data_frames % st->d->samples_in_100ms) {
     /* round up to multiple of samples_in_100ms */
     st->d->audio_data_frames =


### PR DESCRIPTION
This fixes an integer overflow that results in libebur128 calculating 0.0 for the loudness range for DSD512 files on Windows.

The sample rate for these files (2822400 samples/sec) multiplied by the window size (3000) overflows a 32 bit integer, resulting in a value for `audio_data_frames` being half what it should be.  This PR re-orders the arithmetic to reduce the size of the intermediate values.

This doesn't happen on Linux/Mac because on those platforms `unsigned long` is 64 bits, but for Windows `unsigned long` is 32 bits on 64 bit systems.