### PR TITLE
Use #pragma instead of #warning with MSVC

### DIFF
--- a/ebur128/ebur128.c
+++ b/ebur128/ebur128.c
@@ -606,7 +606,13 @@ static void ebur128_check_true_peak(ebur128_state* st, size_t frames) {
 #define TURN_OFF_FTZ _mm_setcsr(mxcsr);
 #define FLUSH_MANUALLY
 #else
-#warning "manual FTZ is being used, please enable SSE2 (-msse2 -mfpmath=sse)"
+#define SSE2_WARNING \
+  "manual FTZ is being used, please enable SSE2 (-msse2 -mfpmath=sse)"
+#ifdef _MSC_VER
+#pragma message ( SSE2_WARNING )
+#else
+#warning SSE2_WARNING
+#endif
 #define TURN_ON_FTZ
 #define TURN_OFF_FTZ
 #define FLUSH_MANUALLY                                                         \


### PR DESCRIPTION
I was attempting to create an experimental build with Windows ARM64, but MSVC didn't like the `#warning` on line 609 during the FTZ/SSE2 checks. This simple fix just uses `#pragma` instead to send out the warning if MSVC is detected. This will probably need refactored if #127 gets approved at some point.